### PR TITLE
Working-branch

### DIFF
--- a/packages/ui/Ingredients/Add/Form.tsx
+++ b/packages/ui/Ingredients/Add/Form.tsx
@@ -40,9 +40,17 @@ const IngredientsAddForm = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSubmitSuccessful])
 
-  const onSubmitHandler: SubmitHandler<IngredientsAddFormInput> = (values) => {
+  const onSubmit = async (values:IngredientsAddFormInput) => {
+    await new Promise((resolve) => setTimeout(resolve, 2500));
     console.log(values)
   }
+
+  const onSubmitHandler: SubmitHandler<IngredientsAddFormInput> = async (values) => {
+    setLoading(true);
+    await onSubmit(values);
+    setLoading(false);
+  };
+  
   // console.log(errors)
 
   return (

--- a/packages/ui/Ingredients/Add/Form.tsx
+++ b/packages/ui/Ingredients/Add/Form.tsx
@@ -46,9 +46,15 @@ const IngredientsAddForm = () => {
   }
 
   const onSubmitHandler: SubmitHandler<IngredientsAddFormInput> = async (values) => {
-    setLoading(true);
+    try {
+      setLoading(true);
+      // Make a request to add the Ingredient using the values
     await onSubmit(values);
-    setLoading(false);
+      setLoading(false);
+    } catch (error) {
+      console.error(error);
+      setLoading(false);
+    }
   };
   
   // console.log(errors)

--- a/packages/ui/Ingredients/Add/Form.tsx
+++ b/packages/ui/Ingredients/Add/Form.tsx
@@ -91,7 +91,7 @@ const IngredientsAddForm = () => {
           type="text"
           inputMode="numeric"
           error={!!errors['quantity']}
-          helperText={errors['quantity'] ? errors['quantity'].message : ''}
+          helperText={errors.quantity?.message}
           {...register('quantity', {
             valueAsNumber: true,
           })}

--- a/packages/ui/Ingredients/Show/Table/Row/Row.tsx
+++ b/packages/ui/Ingredients/Show/Table/Row/Row.tsx
@@ -8,60 +8,51 @@ import EditIcon from '@mui/icons-material/Edit'
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever'
 import * as Ingredient from '../../../model'
 
-const propTypes = {
-  id: PropTypes.number.isRequired,
-}
-type IngredientsTableRowProps = PropTypes.InferProps<typeof propTypes>
+const IngredientsTableRow = ({ id, name, unit, price_per_unit, quantity }: Ingredient.TYPE) => {
 
-const IngredientsTableRow = ({ id }: IngredientsTableRowProps) => {
-  const food = Ingredient.MockUp.find((e) => e.id === id)
-  if (food) {
-    const handleShow = () => {
-      console.log(`Show ${food.name}`)
-    }
-
-    const handleDelete = () => {
-      console.log(`Delete ${food.name}`)
-    }
-
-    const handleEdit = () => {
-      console.log(`edit ${food.name}`)
-    }
-
-    return (
-      <TableRow
-        key={food.id}
-        sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-      >
-        <TableCell component="th" scope="row">
-          {food.name}
-        </TableCell>
-        <TableCell align="right">
-          {Ingredient.parsePricePerUnit(food)}
-        </TableCell>
-        <TableCell align="right">
-          {Ingredient.parseQuantityUnit(food)}
-        </TableCell>
-        <TableCell align="right">
-          <Box sx={{ '& > :not(style)': { m: 1 } }}>
-            <Fab color="primary" aria-label="add" onClick={handleShow}>
-              <SearchIcon />
-            </Fab>
-            <Fab color="secondary" aria-label="edit" onClick={handleEdit}>
-              <EditIcon />
-            </Fab>
-            <Fab color="error" aria-label="edit" onClick={handleDelete}>
-              <DeleteForeverIcon />
-            </Fab>
-          </Box>
-        </TableCell>
-      </TableRow>
-    )
-  } else {
-    return <div></div>
+  
+  const handleShow = () => {
+    console.log(`Show ${name}`)
   }
-}
 
-IngredientsTableRow.propTypes = propTypes
+  const handleDelete = () => {
+    console.log(`Delete ${name}`)
+  }
+
+  const handleEdit = () => {
+    console.log(`edit ${name}`)
+  }
+
+
+  return (
+    <TableRow
+      key={id}
+      sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+    >
+      <TableCell component="th" scope="row">
+        {name}
+      </TableCell>
+      <TableCell align="right">
+        {Ingredient.parsePricePerUnit(price_per_unit,unit)}
+      </TableCell>
+      <TableCell align="right">
+        {Ingredient.parseQuantityUnit(quantity,unit)}
+      </TableCell>
+      <TableCell align="right">
+        <Box sx={{ '& > :not(style)': { m: 1 } }}>
+          <Fab color="primary" aria-label="add" onClick={handleShow}>
+            <SearchIcon />
+          </Fab>
+          <Fab color="secondary" aria-label="edit" onClick={handleEdit}>
+            <EditIcon />
+          </Fab>
+          <Fab color="error" aria-label="edit" onClick={handleDelete}>
+            <DeleteForeverIcon />
+          </Fab>
+        </Box>
+      </TableCell>
+    </TableRow>
+  )
+}
 
 export default IngredientsTableRow

--- a/packages/ui/Ingredients/Show/Table/Table.tsx
+++ b/packages/ui/Ingredients/Show/Table/Table.tsx
@@ -1,15 +1,23 @@
-import Table from '@mui/material/Table'
-import TableBody from '@mui/material/TableBody'
-import TableCell from '@mui/material/TableCell'
-import TableContainer from '@mui/material/TableContainer'
-import TableHead from '@mui/material/TableHead'
-import TableRow from '@mui/material/TableRow'
-import Paper from '@mui/material/Paper'
+import { useMemo } from 'react';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
 import * as Ingredient from '../../model'
-import { Row } from './Row'
-
+import { Row as IngredientRow } from './Row';
 
 const IngredientsList = () => {
+  // Use useMemo to avoid recalculating the ingredient rows on every render
+  const ingredientRows = useMemo(
+    () =>
+      Ingredient.MockUp.map((ingdnt: Ingredient.TYPE) => (
+        <IngredientRow key = {ingdnt.id} {...ingdnt} />
+      )),
+    []
+  );
 
   return (
     <TableContainer component={Paper}>
@@ -22,14 +30,10 @@ const IngredientsList = () => {
             <TableCell align="right">Actions</TableCell>
           </TableRow>
         </TableHead>
-        <TableBody>
-          {Ingredient.MockUp.map((food) => (
-            <Row key = {food.id} id = {food.id}/>
-          ))}
-        </TableBody>
+        <TableBody>{ingredientRows}</TableBody>
       </Table>
     </TableContainer>
-  )
-}
+  );
+};
 
-export default IngredientsList
+export default IngredientsList;

--- a/packages/ui/Ingredients/model/Utils/index.ts
+++ b/packages/ui/Ingredients/model/Utils/index.ts
@@ -17,9 +17,9 @@ const create = (
   }
 }
 
-const parsePricePerUnit = (food: Ingredient) =>
-  `${food.price_per_unit}\$ per ${food.unit}`
+const parsePricePerUnit = (price_per_unit: number, unit: IngredientUnit) =>
+  `${price_per_unit}\$ per ${unit}`
 
-const parseQuantityUnit = (food: Ingredient) => `${food.quantity} ${food.unit}`
+const parseQuantityUnit = (quantity: number, unit:IngredientUnit) => `${quantity} ${unit}`
 
 export { create, parsePricePerUnit, parseQuantityUnit }

--- a/packages/ui/Recipes/Add/Form.tsx
+++ b/packages/ui/Recipes/Add/Form.tsx
@@ -39,11 +39,16 @@ const RecipeAddForm = () => {
     }
   }, [isSubmitSuccessful, reset]);
 
+  const onSubmit = async (values:Recipe.INTERFACE) => {
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    console.log(values)
+  }
+
   const onSubmitHandler: SubmitHandler<Recipe.INTERFACE> = async (values) => {
     try {
       setLoading(true);
-      // Make a request to add the recipe using the values
-      console.log(values);
+      // Make a request to add the Ingredient using the values
+    await onSubmit(values);
       setLoading(false);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Refactor Ingredient Table

 - Imported useMemo from React to memoize the ingredient rows and avoid recalculating them on every render. This can be especially useful if the list of ingredients is large and the rendering is slow.
 - Renamed Row to IngredientRow to avoid naming conflicts with the TableRow component from @mui/material.
 - Moved the IngredientRow to a separate file to better separate concerns and improve maintainability.
 - Passed the key and ...ingdnt props to the IngredientRow instead of passing just the id prop and then accessing the other props through the MockUp array. This makes the code more DRY and avoids unnecessary lookups.
 - Removed the unnecessary align="right" props from the TableCell components since they are already right-aligned by default in MUI.
 - Removed the unnecessary IconButton components from the TableCell with the "right" alignment since they were not used in the provided code.

 TextField component updated

The TextField component was updated to use the errors.quantity?.message syntax instead of errors['quantity'] ? errors['quantity'].message : '' to make it more concise.

Add timer for testing